### PR TITLE
Fix code scanning alert no. 20: Cross-site scripting

### DIFF
--- a/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
+++ b/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
@@ -23,9 +23,10 @@ namespace OWASP.WebGoat.NET.WebGoatCoins
             //context.Response.Write("Hello World");
 
             string query = context.Request["query"];
+            string encodedQuery = System.Net.WebUtility.HtmlEncode(query);
             
-            DataSet ds = du.GetCustomerEmails(query);
-            string json = Encoder.ToJSONSAutocompleteString(query, ds.Tables[0]);
+            DataSet ds = du.GetCustomerEmails(encodedQuery);
+            string json = Encoder.ToJSONSAutocompleteString(encodedQuery, ds.Tables[0]);
 
             if (json != null && json.Length > 0)
             {


### PR DESCRIPTION
Fixes [https://github.com/Diegofcv-git/ghas-demo-csharp/security/code-scanning/20](https://github.com/Diegofcv-git/ghas-demo-csharp/security/code-scanning/20)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided input is properly sanitized or encoded before being included in the HTTP response. In this case, we should use the `System.Net.WebUtility.HtmlEncode` method to encode the `query` parameter before it is used in generating the `json` string. This will prevent any malicious scripts from being executed in the user's browser.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
